### PR TITLE
Fix backup file formats and update devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,11 @@
 {
   "name": "Emergency Mode Disaster Risk",
   "image": "mcr.microsoft.com/devcontainers/python:3.13",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  },
   "updateRemoteUserUID": false,
   "customizations": {
     "vscode": {

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 set -e
 
-# Install uv
-curl -LsSf https://astral.sh/uv/install.sh | sh
+# Install uv in user space if needed
+if ! command -v uv >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+
+# Ensure user-level binaries are available in this shell
+export PATH="$HOME/.local/bin:$PATH"
 
 # Create venv and install all project dependencies
 uv sync

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   # Maintain npm dependencies (WordPress plugins)
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "staging"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
@@ -20,6 +21,7 @@ updates:
   # Maintain GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "staging"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "emergencymode-news",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "emergencymode-news",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "devDependencies": {
         "prettier": "^3.8.3"
       }

--- a/tools/scripts/WPAppScript.js
+++ b/tools/scripts/WPAppScript.js
@@ -9,7 +9,7 @@ const DEFAULT_FIELDS = ["id", "slug", "description", "status", "count", "link"];
 
 /**
  * Main function to fetch WordPress REST API data
- * 
+ *
  * @param {string} endpoint - The endpoint to fetch from: 'categories', 'tags', 'pages', or 'posts'
  * @param {Object} options - Optional configuration object
  * @param {string|number} options.filter - Filter by id, slug, or name
@@ -24,20 +24,20 @@ function fetchWPData(endpoint, options = {}) {
   if (!ALLOWED_ENDPOINTS.includes(endpoint)) {
     throw new Error(`Invalid endpoint. Must be one of: ${ALLOWED_ENDPOINTS.join(", ")}`);
   }
-  
+
   // Set defaults
   const fields = options.fields || DEFAULT_FIELDS;
   const perPage = Math.min(options.perPage || 100, 100);
   const flattenForSheets = options.flattenForSheets || false;
-  
+
   // Build URL
   let url = `${WP_BASE_URL}/${endpoint}`;
   const params = [`per_page=${perPage}`];
-  
+
   // Handle filtering
   if (options.filter !== undefined && options.filter !== null && options.filter !== "") {
     const filterType = options.filterType || detectFilterType(options.filter);
-    
+
     if (filterType === "id") {
       // Fetch specific item by ID
       url = `${url}/${options.filter}`;
@@ -47,30 +47,29 @@ function fetchWPData(endpoint, options = {}) {
       params.push(`search=${encodeURIComponent(options.filter)}`);
     }
   }
-  
+
   // Add params to URL
   if (params.length > 0 && !url.includes(options.filter + "")) {
     url += "?" + params.join("&");
   }
-  
+
   try {
     // Fetch data
     const response = UrlFetchApp.fetch(url);
     const data = JSON.parse(response.getContentText());
-    
+
     // Normalize to array
     const items = Array.isArray(data) ? data : [data];
-    
+
     // Extract specified fields
     const filtered = items.map(item => extractFields(item, fields));
-    
+
     // Return in requested format
     if (flattenForSheets) {
       return flattenForSheetsOutput(filtered, fields);
     }
-    
+
     return filtered;
-    
   } catch (error) {
     Logger.log(`Error fetching from ${url}: ${error.message}`);
     throw new Error(`Failed to fetch ${endpoint}: ${error.message}`);
@@ -95,7 +94,7 @@ function detectFilterType(value) {
  */
 function extractFields(item, fields) {
   const result = {};
-  
+
   fields.forEach(field => {
     // Handle nested fields with dot notation
     if (field.includes(".")) {
@@ -109,7 +108,7 @@ function extractFields(item, fields) {
       result[field] = item[field] !== undefined ? item[field] : null;
     }
   });
-  
+
   return result;
 }
 
@@ -120,10 +119,10 @@ function flattenForSheetsOutput(data, fields) {
   if (!data || data.length === 0) {
     return [fields, []]; // Return headers and empty row
   }
-  
+
   // Header row
   const output = [fields];
-  
+
   // Data rows
   data.forEach(item => {
     const row = fields.map(field => {
@@ -136,7 +135,7 @@ function flattenForSheetsOutput(data, fields) {
     });
     output.push(row);
   });
-  
+
   return output;
 }
 
@@ -150,11 +149,11 @@ function flattenForSheetsOutput(data, fields) {
  */
 function getCategories(filter = null, returnFields = null) {
   const options = {
-    flattenForSheets: true
+    flattenForSheets: true,
   };
   if (filter) options.filter = filter;
   if (returnFields) options.fields = returnFields.split(",").map(f => f.trim());
-  
+
   return fetchWPData("categories", options);
 }
 
@@ -164,11 +163,11 @@ function getCategories(filter = null, returnFields = null) {
  */
 function getTags(filter = null, returnFields = null) {
   const options = {
-    flattenForSheets: true
+    flattenForSheets: true,
   };
   if (filter) options.filter = filter;
   if (returnFields) options.fields = returnFields.split(",").map(f => f.trim());
-  
+
   return fetchWPData("tags", options);
 }
 
@@ -178,11 +177,11 @@ function getTags(filter = null, returnFields = null) {
  */
 function getPages(filter = null, returnFields = null) {
   const options = {
-    flattenForSheets: true
+    flattenForSheets: true,
   };
   if (filter) options.filter = filter;
   if (returnFields) options.fields = returnFields.split(",").map(f => f.trim());
-  
+
   return fetchWPData("pages", options);
 }
 
@@ -192,11 +191,11 @@ function getPages(filter = null, returnFields = null) {
  */
 function getPosts(filter = null, returnFields = null) {
   const options = {
-    flattenForSheets: true
+    flattenForSheets: true,
   };
   if (filter) options.filter = filter;
   if (returnFields) options.fields = returnFields.split(",").map(f => f.trim());
-  
+
   return fetchWPData("posts", options);
 }
 
@@ -206,10 +205,10 @@ function getPosts(filter = null, returnFields = null) {
  */
 function getWPData(endpoint, filter = null, returnFields = null) {
   const options = {
-    flattenForSheets: true
+    flattenForSheets: true,
   };
   if (filter) options.filter = filter;
   if (returnFields) options.fields = returnFields.split(",").map(f => f.trim());
-  
+
   return fetchWPData(endpoint, options);
 }

--- a/tools/styles/css.css
+++ b/tools/styles/css.css
@@ -7,174 +7,174 @@
  * But you may still need `!important` to fight long selectors or third-party plugin CSS
  */
 
- /*custom bkg*/
+/*custom bkg*/
 body {
   background-color: rgb(249, 248, 246);
 }
 
 /*custom header*/
 .h-sb header#masthead {
-	backdrop-filter: blur(12px);
-	background-color: rgba(249,248,246,0.75) !important;
-	background-color: oklab(0.978916 0.00032109 0.00292373 / 0.8);
+  backdrop-filter: blur(12px);
+  background-color: rgba(249, 248, 246, 0.75) !important;
+  background-color: oklab(0.978916 0.00032109 0.00292373 / 0.8);
 }
 .h-sb header#masthead .middle-header-contain {
-	background-color: transparent !important;
+  background-color: transparent !important;
 }
 
 /* site title*/
 .site-title a {
   color: #c1503d !important;
   font-size: 1rem;
-  font-family: 'Roboto Slab', serif;
+  font-family: "Roboto Slab", serif;
 }
 
 /* wide-site helper*/
 .max-width {
-	max-width: 800px !important;
+  max-width: 800px !important;
 }
 
 /* Show Breadcrumbs only on Archive pages*/
 .site-breadcrumb {
-	display: none !important;
+  display: none !important;
 }
 body.archive .site-breadcrumb {
-	display: inherit !important;
+  display: inherit !important;
 }
 
 /*capitalize By in all normal bylines*/
 .entry-meta .byline:not(.sponsor-byline) > span {
-	text-transform: capitalize; 
+  text-transform: capitalize;
 }
 
 /* restyle border on blockquotes */
 .h-stk .entry-content [id] {
-	border-color: #B7B4AF;
+  border-color: #b7b4af;
 }
 
 /* convert all horizontal rules to rounded-corner style */
 hr,
-.entry .entry-content>.wp-block-separator, .entry .entry-content>hr,
+.entry .entry-content > .wp-block-separator,
+.entry .entry-content > hr,
 .rounded-hr {
-	background-color: var(--newspack-theme-color-primary);
-	border-radius: 3px;
-	width: 100px !important;
-	height: 6px !important;
+  background-color: var(--newspack-theme-color-primary);
+  border-radius: 3px;
+  width: 100px !important;
+  height: 6px !important;
 }
 
 /* apply our styles to tables with .emfn-table */
 figure.emfn-table.wp-block-table > table {
-	max-width: 80% !important;
+  max-width: 80% !important;
 }
 figure.emfn-table.wp-block-table thead {
-	border-color: #B7B4AF;
+  border-color: #b7b4af;
 }
 figure.emfn-table.wp-block-table thead th {
-	border: none;
+  border: none;
 }
 figure.emfn-table.wp-block-table tbody tr:not(:last-of-type) {
-	border: 1px solid #B7B4AF;
-	border-width: 1px 0px;
+  border: 1px solid #b7b4af;
+  border-width: 1px 0px;
 }
 figure.emfn-table.wp-block-table tbody td {
-	border-width: 0px;
+  border-width: 0px;
 }
 figure.emfn-table.wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
-    background-color: #efece7;
+  background-color: #efece7;
 }
 
 /* apply our styles to Details blocks*/
 .wp-block-details {
-	border-width: 0px;
-	border-bottom: 1px solid #B7B4AF;
-	display: block;
-	width: 100%;
-	margin-bottom: 32px !important;
+  border-width: 0px;
+  border-bottom: 1px solid #b7b4af;
+  display: block;
+  width: 100%;
+  margin-bottom: 32px !important;
 }
 .wp-block-details:last-of-type {
-	border-bottom-width: 0px;
+  border-bottom-width: 0px;
 }
 
 /*knock out magins on .above-footer widget content*/
 .above-footer-widgets .wrapper {
-	margin: auto;
-	max-width: 100vw;
-	width: auto;
+  margin: auto;
+  max-width: 100vw;
+  width: auto;
 }
 .above-footer-widgets .wrapper .above-footer.widget {
-	margin-bottom: 0px !important;
+  margin-bottom: 0px !important;
 }
-
 
 /*hide breadcrumbs on homepage*/
 body.home .site-breadcrumb {
-	display: none !important;
+  display: none !important;
 }
 
 /* Content - Breadcrumbs */
 @media (min-width: 782px) {
-	.site-breadcrumb {
-		margin: 1.5rem 0 0.25rem;
-	}
+  .site-breadcrumb {
+    margin: 1.5rem 0 0.25rem;
+  }
 }
 
 .site-breadcrumb .wrapper > span {
-	color: var( --newspack-theme-color-text-main );
-	display: flex;
-	flex-wrap: wrap;
-	font-family: var( --newspack-theme-font-display );
-	font-size: 14px;
-	gap: 0.5em;
+  color: var(--newspack-theme-color-text-main);
+  display: flex;
+  flex-wrap: wrap;
+  font-family: var(--newspack-theme-font-display);
+  font-size: 14px;
+  gap: 0.5em;
 }
 
 .site-breadcrumb .breadcrumb_last {
-	font-weight: bold;
-	border-bottom: 2px solid var( --newspack-theme-color-secondary );
+  font-weight: bold;
+  border-bottom: 2px solid var(--newspack-theme-color-secondary);
 }
 
 /*hide search bar in header*/
 body.home .header-search-contain {
-	display: none !important;
+  display: none !important;
 }
 
 /*hide >4 categories on Post pages (9 = 4, because hidden commas) */
 /* Newspack's 'only show Yoast primary category' flag SHOULD drive this, but if it is turned off this is a catch-all */
-.cat-links > :nth-child(n+9) {
-    display: none;
+.cat-links > :nth-child(n + 9) {
+  display: none;
 }
 
 /*left-align logo*/
 .h-sh.h-ll .site-branding {
-    margin-right: auto;
+  margin-right: auto;
 }
 
 /*right-align primary and tertiary navs */
 .h-sh .site-header .wrapper {
-    justify-content: space-between;
+  justify-content: space-between;
 }
 
 /* drop forced separation of nav locations*/
-.h-sh.h-ll.hide-site-tagline.has-tertiary-menu .nav-wrapper+.nav-wrapper {
-	margin-left: 10px;
+.h-sh.h-ll.hide-site-tagline.has-tertiary-menu .nav-wrapper + .nav-wrapper {
+  margin-left: 10px;
 }
 
 /*convert nav3/tertiary to our style of button*/
 .site-header .nav3 li a {
-	background-color: #c1503d !important;
-	color: #FFF !important;
-	border-radius: 32px;
-	padding: 6px 24px;
-	text-align: center;
+  background-color: #c1503d !important;
+  color: #fff !important;
+  border-radius: 32px;
+  padding: 6px 24px;
+  text-align: center;
 }
 
 /*restyle footer text*/
-.site-info, .site-info a {
-	color: var(--newspack-theme-color-primary);
-	font-weight: 200;
-	font-style: normal;
-	font-size: var(--wp--preset--font-size--small) !important;
+.site-info,
+.site-info a {
+  color: var(--newspack-theme-color-primary);
+  font-weight: 200;
+  font-style: normal;
+  font-size: var(--wp--preset--font-size--small) !important;
 }
-
 
 /** ********** ACTION PACK ********** 
  * styles for Action Pack quiz & response page
@@ -188,58 +188,59 @@ body.home .header-search-contain {
  */
 /* action items*/
 .action-item {
-	background-color: oklab(0.98 -0.02 0.01);
+  background-color: oklab(0.98 -0.02 0.01);
   border-radius: 16px;
   padding: 20px;
   color: #009966;
   list-style: none;
-	margin: 0px;
+  margin: 0px;
 }
 .action-item p {
-	margin: 0px;
+  margin: 0px;
 }
-.action-item a,.action-item a:link, .action-item a:visited {
+.action-item a,
+.action-item a:link,
+.action-item a:visited {
   color: #00724c;
 }
 .action-item li.template {
-	display: flex;
+  display: flex;
   align-items: flex-start;
   gap: 16px;
 }
 .action-item li.template .material-symbols-outlined {
-    flex-shrink: 0;
-    float: none;
+  flex-shrink: 0;
+  float: none;
 }
 
 /* FEMA risk explanation within question Description */
 #fema-risks {
-	margin: 0px;
-	padding: 0px;
-	font-size: var(--newspack-theme-font-size-xs);
+  margin: 0px;
+  padding: 0px;
+  font-size: var(--newspack-theme-font-size-xs);
 }
 
 /* Center title only in Action Pack pages*/
 body.parent-pageid-284 .entry-header {
-	text-align: center;
+  text-align: center;
 }
 
 /*Content Loop adjustments*/
-.emfn-content-cards.wpnbha  .article-section-title
-{
+.emfn-content-cards.wpnbha .article-section-title {
   border-bottom: 1px solid #e3e1dd;
 }
 .archive article.entry .entry-content > * {
-	border-top: 1px solid #e3e1dd;
-	padding-top: 0px;
-	margin-top: 0px;
+  border-top: 1px solid #e3e1dd;
+  padding-top: 0px;
+  margin-top: 0px;
 }
-.emfn-content-cards.wpnbha article, 
-.archive article.entry { 
-	padding: 24px 36px 20px 36px;
-	background-color: #FFF;
-	border-radius: 24px;
-	border: 1px solid #E2E2E2;
-	box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px;
+.emfn-content-cards.wpnbha article,
+.archive article.entry {
+  padding: 24px 36px 20px 36px;
+  background-color: #fff;
+  border-radius: 24px;
+  border: 1px solid #e2e2e2;
+  box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px;
 }
 
 /* Republishable Card Peach */
@@ -248,79 +249,79 @@ body.parent-pageid-284 .entry-header {
   border: 1px solid #ffd7a8;
 }
 .emfn-content-cards.wpnbha article.category-republishable .entry-wrapper .entry-meta {
-	border-top-color: #ffd7a8;
+  border-top-color: #ffd7a8;
 }
 /* Republishable Category link */
 .emfn-content-cards.wpnbha article.category-republishable .cat-links a {
-	color: #9f2d00;
-	border: 1px solid #ffd7a8;
-	background-color: #efece750;
+  color: #9f2d00;
+  border: 1px solid #ffd7a8;
+  background-color: #efece750;
 }
 
 /*all Card Categories*/
 .emfn-content-cards.wpnbha .cat-links a {
-	background-color: #FFF;
-	border: 1px solid #CCC;
-	color: var(--newspack-theme-color-text-light);
-	gap: 0em 1.0em;
-	display: inline-block;
-	padding: 6px 12px;
-	border-radius: 8px;
-	margin-bottom: 10px;	
+  background-color: #fff;
+  border: 1px solid #ccc;
+  color: var(--newspack-theme-color-text-light);
+  gap: 0em 1em;
+  display: inline-block;
+  padding: 6px 12px;
+  border-radius: 8px;
+  margin-bottom: 10px;
 }
 .emfn-content-cards.wpnbha .cat-links a:hover,
 .emfn-content-cards.wpnbha .cat-links a:link:hover {
-	border-color: #999;
-	color: var(--newspack-theme-color-text-medium);
-	background-color: #efece790;
-	text-decoration-color: var(--newspack-theme-color-text-medium);
+  border-color: #999;
+  color: var(--newspack-theme-color-text-medium);
+  background-color: #efece790;
+  text-decoration-color: var(--newspack-theme-color-text-medium);
 }
 .emfn-content-cards.wpnbha .entry-sponsors {
-	width: auto;
+  width: auto;
 }
 .emfn-content-cards.wpnbha .entry-sponsors.plus-author:not(:last-child) {
-	margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 /*Card bylines*/
 .emfn-content-cards.wpnbha .entry-wrapper .entry-meta {
-	color: var(--newspack-theme-color-text-light);
-	border-top: 1px solid #efece7;
-	gap: 0.5em 0.25em;
-	margin-top: 12px;
-	padding-top: 12px;
+  color: var(--newspack-theme-color-text-light);
+  border-top: 1px solid #efece7;
+  gap: 0.5em 0.25em;
+  margin-top: 12px;
+  padding-top: 12px;
 }
 .emfn-content-cards.wpnbha .entry-wrapper .entry-meta,
-.emfn-content-cards.wpnbha .entry-sponsors.plus-author{
-	color: var(--newspack-theme-color-text-light);
-	font-size: 13px !important;
+.emfn-content-cards.wpnbha .entry-sponsors.plus-author {
+  color: var(--newspack-theme-color-text-light);
+  font-size: 13px !important;
 }
-.emfn-content-cards.wpnbha .entry-wrapper .entry-meta .byline, 
+.emfn-content-cards.wpnbha .entry-wrapper .entry-meta .byline,
 .emfn-content-cards.wpnbha .entry-wrapper .entry-meta .entry-date {
-	margin-right: 10px;
+  margin-right: 10px;
 }
 
 /* Article body*/
 .emfn-content-cards.wpnbha .entry-wrapper p {
-	padding: 6px 0px;
+  padding: 6px 0px;
 }
 .single:not(.has-large-featured-image) .entry-header {
-	border-bottom-color: #CCC;
+  border-bottom-color: #ccc;
 }
 
 /* Content Loop load-more button */
 .emfn-content-cards.wpnbha.has-more-button button {
-	background-color: #FFF;
-	border-radius: 8px;
-	border: 1px solid #888;
-	box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px;
-	color: var(--newspack-theme-color-primary);
-	margin-top: 2em;
-	padding: 14px 18px;	
+  background-color: #fff;
+  border-radius: 8px;
+  border: 1px solid #888;
+  box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px;
+  color: var(--newspack-theme-color-primary);
+  margin-top: 2em;
+  padding: 14px 18px;
 }
 .emfn-content-cards.wpnbha.has-more-button button:hover {
-	background-color: #E8E8E8;
-	border-color: #666;
+  background-color: #e8e8e8;
+  border-color: #666;
 }
 
 /** ********** SPONSOR & CATEGORY LABELS ********** 
@@ -331,37 +332,37 @@ body.parent-pageid-284 .entry-header {
 /* hide all sponsor labels */
 .cat-links span.flag,
 .archive article .sponsor-label {
-	display: none;
+  display: none;
 }
 
 /* alter non-Card Category labels */
 .cat-links a {
-	color: #FFF;
-	text-transform: none;
-	border: 1px solid var(--newspack-theme-color-primary-darken-10);
-	background-color: var(--newspack-theme-color-primary);
-	display: inline-block;
-	padding: 6px 12px;
-	border-radius: 8px;
-	margin-bottom: 10px;
-	text-decoration: none;
+  color: #fff;
+  text-transform: none;
+  border: 1px solid var(--newspack-theme-color-primary-darken-10);
+  background-color: var(--newspack-theme-color-primary);
+  display: inline-block;
+  padding: 6px 12px;
+  border-radius: 8px;
+  margin-bottom: 10px;
+  text-decoration: none;
 }
 .cat-links a:hover {
-	background-color: var(--newspack-theme-color-primary-darken-10);
+  background-color: var(--newspack-theme-color-primary-darken-10);
 }
 
 /* alter non-Card Tags */
 .tags-links a {
-	border: 1px solid #CCC;
-	background-color: #FFF;
-	padding: 10px 15px;
-	border-radius: 8px;
-	line-height: 1em;
-	text-decoration: none;
-	box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px;
+  border: 1px solid #ccc;
+  background-color: #fff;
+  padding: 10px 15px;
+  border-radius: 8px;
+  line-height: 1em;
+  text-decoration: none;
+  box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px;
 }
 .tags-links a:hover {
-	border-color: #999;
+  border-color: #999;
 }
 
 /** 
@@ -369,36 +370,30 @@ body.parent-pageid-284 .entry-header {
  * used tetradic colors off https://www.colorhexa.com/e7bbb4
  */
 /* all Resource pills & Timing category group*/
-.emfn-content-cards.wpnbha.show-category .cat-links a[href]
- {
-	 --cat-color: #F1F1F1;
-	background-color: var(--cat-color);
-	border: 1px solid color-mix(in srgb, var(--cat-color), black 15%);
-	 color: color-mix(in srgb, var(--cat-color), black 66%);
+.emfn-content-cards.wpnbha.show-category .cat-links a[href] {
+  --cat-color: #f1f1f1;
+  background-color: var(--cat-color);
+  border: 1px solid color-mix(in srgb, var(--cat-color), black 15%);
+  color: color-mix(in srgb, var(--cat-color), black 66%);
 }
 
 /* Disaster category group*/
-.emfn-content-cards.wpnbha.show-category .cat-links a[href*="resources/disasters/"]
-{
-	--cat-color: #e7bbb4;
+.emfn-content-cards.wpnbha.show-category .cat-links a[href*="resources/disasters/"] {
+  --cat-color: #e7bbb4;
 }
 
 /* Operational Challenge category group*/
-.emfn-content-cards.wpnbha.show-category .cat-links a[href*="resources/challenge/"]
-{
-	--cat-color: #b4e7bb;
+.emfn-content-cards.wpnbha.show-category .cat-links a[href*="resources/challenge/"] {
+  --cat-color: #b4e7bb;
 }
 /* Type category group*/
-.emfn-content-cards.wpnbha.show-category .cat-links a[href*="resources/type/"]
-{
-	--cat-color: #b4e0e7;
+.emfn-content-cards.wpnbha.show-category .cat-links a[href*="resources/type/"] {
+  --cat-color: #b4e0e7;
 }
 /* Newsroom Condition category group*/
-.emfn-content-cards.wpnbha.show-category .cat-links a[href*="resources/newsroom-condition/"]
-{
-	--cat-color: #e7b4e0;
+.emfn-content-cards.wpnbha.show-category .cat-links a[href*="resources/newsroom-condition/"] {
+  --cat-color: #e7b4e0;
 }
-
 
 /** ********** JETPACK AI SEARCH ********** 
  * styles overrides for Jetpack AI search box and results
@@ -406,39 +401,39 @@ body.parent-pageid-284 .entry-header {
  */
 /*Jetpack AI search*/
 .emfn-ai-search {
-	min-height: 50px;
-	width: 100%;
+  min-height: 50px;
+  width: 100%;
 }
 .emfn-ai-search .jetpack-ai-chat-question-wrapper,
 .emfn-ai-search .jetpack-ai-chat-question-input {
-	margin: 0px !important;
+  margin: 0px !important;
 }
-.emfn-ai-search input[type="text"], 
+.emfn-ai-search input[type="text"],
 .emfn-ai-search button[type="button"] {
-	background-color: #FFF;
+  background-color: #fff;
   border-radius: 8px;
   box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px;
   color: var(--newspack-theme-color-primary);
-	padding: 14px 18px;
-	border: 1px solid #888;
-	color: #c1503d;
-	height: 50px !important;
+  padding: 14px 18px;
+  border: 1px solid #888;
+  color: #c1503d;
+  height: 50px !important;
 }
 .emfn-ai-search input[type="text"]:focus {
-	background-color: #FFF;
-	border-color: #c1503d;
-	box-shadow: rgba(0,0,0,0.03) 0px 0px 6px 2px;
+  background-color: #fff;
+  border-color: #c1503d;
+  box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px;
 }
 .emfn-ai-search button[type="button"]:hover,
 .emfn-ai-search button[type="button"]:active,
 .emfn-ai-search button[type="button"]:focus {
-	background-color: #E8E8E8;
-	box-shadow: rgba(0,0,0,0.03) 0px 0px 6px 2px;
-	border-color: #777;
-	color: #c1503d;
+  background-color: #e8e8e8;
+  box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px;
+  border-color: #777;
+  color: #c1503d;
 }
 .emfn-ai-search .jetpack-ai-chat-copy-button {
-	padding: 0px 10px;
+  padding: 0px 10px;
 }
 
 /** ********** SYMBOLS FONT ********** 
@@ -447,31 +442,31 @@ body.parent-pageid-284 .entry-header {
  */
 .material-symbols-outlined,
 .material-symbols-outlined > a {
-	background-color: transparent;
+  background-color: transparent;
   font-family: "Material Symbols Outlined", sans-serif;
   font-weight: 600;
   font-style: normal;
-	font-size: 50px;
+  font-size: 50px;
   font-variation-settings:
-  'FILL' 0,
-  'wght' 400,
-  'GRAD' 0,
-  'opsz' 24;
-	max-height: 50px;
-	width: auto;
-	overflow: hidden;
-	text-align: center;
+    "FILL" 0,
+    "wght" 400,
+    "GRAD" 0,
+    "opsz" 24;
+  max-height: 50px;
+  width: auto;
+  overflow: hidden;
+  text-align: center;
 }
 .floated-icon {
-	float: left;
-	padding-right: 10px;
-	max-width: 46px;
-	overflow: hidden;
+  float: left;
+  padding-right: 10px;
+  max-width: 46px;
+  overflow: hidden;
 }
 .wp-block-columns .wp-block-column .wp-block-heading > span.material-symbols-outlined {
-	margin-top: -5px;
-    float: left;
-    margin-right: 5px;
+  margin-top: -5px;
+  float: left;
+  margin-right: 5px;
 }
 
 /** ********** BIG BUTTONS ********** 
@@ -523,7 +518,6 @@ body.parent-pageid-284 .entry-header {
   background-color: rgba(218, 70, 45, 0.36) !important;
 }
 
-
 /** ********** HERO ********** 
  * homepage hero styles, including the big headline and the "disaster" word animation
  */
@@ -548,7 +542,9 @@ body.parent-pageid-284 .entry-header {
   text-align: center;
   color: #c1503d;
   opacity: 0;
-  transition: opacity 0.45s ease-in-out, transform 0.45s ease-in-out;
+  transition:
+    opacity 0.45s ease-in-out,
+    transform 0.45s ease-in-out;
   transform: translateY(6px);
   pointer-events: none;
 }
@@ -557,25 +553,179 @@ body.parent-pageid-284 .entry-header {
   transform: translateY(0);
 }
 
-
 /** ********** YOAST FAQ ********** 
  * homepage FAQ styles, including the question and answer formatting
  */
 .schema-faq .schema-faq-section {
-	margin: 50px 0px;
+  margin: 50px 0px;
 }
 
 .schema-faq .schema-faq-section .schema-faq-question:before {
-/* 	content: "Q. ";
+  /* 	content: "Q. ";
 	content: "ⓘ "; */
-	content: "🛈 ";
-	color: var(--newspack-theme-color-primary) !important;
-	font-size: var(--newspack-theme-font-size-md);
-	font-weight: 500;
-	text-align: top;
-	width: 33px;
-	display: inline-block;
+  content: "🛈 ";
+  color: var(--newspack-theme-color-primary) !important;
+  font-size: var(--newspack-theme-font-size-md);
+  font-weight: 500;
+  text-align: top;
+  width: 33px;
+  display: inline-block;
 }
 .schema-faq .schema-faq-section .schema-faq-answer {
-	font-size: var(--newspack-theme-font-size-sm);
+  font-size: var(--newspack-theme-font-size-sm);
+}
+
+/** ********** Newspack Tabs ********** 
+ * override styles for newspack tabs in Pages
+ */
+.emfn-tabs.wp-block-newspack-tabs {
+  background-color: transparent;
+}
+.emfn-tabs.wp-block-newspack-tabs .tab-item.is-active {
+  background-color: #fff;
+  border: 1px solid #e8e8e8;
+}
+
+/** ********** FACETWP CARDS ********** 
+ * styles for the cards that appear in the FacetWP search results on the Resources page, 
+ * which are separate from the main Content Loop cards and need some specific overrides to match our styles
+ */
+.fwpl-result {
+  background-color: #fff !important;
+  border-radius: 24px !important;
+  border: 1px solid #e2e2e2 !important;
+  box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px !important;
+  padding: 24px 36px 20px 36px !important;
+  margin-bottom: 1rem !important;
+}
+
+/* Title */
+.fwpl-item.el-ywvhp a {
+  font-size: 1.2em !important;
+  font-weight: 700 !important;
+  color: #1b2232 !important;
+  text-decoration: none !important;
+  font-family: var(--newspack-theme-font-heading) !important;
+}
+
+.fwpl-item.el-ywvhp a:hover {
+  color: var(--newspack-theme-color-primary) !important;
+}
+
+/* Author and date - same size */
+.fwpl-item.el-7y595n,
+.fwpl-item.el-amrzwf {
+  font-size: 13px !important;
+  color: var(--newspack-theme-color-text-light) !important;
+  display: inline !important;
+  margin-right: 0.75rem !important;
+}
+
+/* Excerpt/subtitle */
+.fwpl-item.el-zz14v8 {
+  font-size: var(--newspack-theme-font-size-sm) !important;
+  font-style: italic !important;
+  line-height: 1.6 !important;
+  margin-top: 0.4rem !important;
+}
+
+/* Keep Reading */
+.fwpl-item.el-qpacxb {
+  margin-top: 8px !important;
+  display: block !important;
+}
+
+.fwpl-btn {
+  color: #1b2232 !important;
+  text-decoration: underline !important;
+  font-size: 0.9em !important;
+}
+
+.fwpl-btn:hover {
+  color: var(--newspack-theme-color-primary) !important;
+}
+
+.facetwp-counter {
+  display: none !important;
+}
+
+/* Search bar */
+.facetwp-search {
+  border: 1px solid #ccc !important;
+  border-radius: 8px !important;
+  padding: 10px 16px !important;
+  font-size: var(--newspack-theme-font-size-sm) !important;
+  width: 100% !important;
+  background-color: #fff !important;
+  color: var(--newspack-theme-color-text-main) !important;
+}
+
+.facetwp-search:focus {
+  border-color: #1b2232 !important;
+  outline: none !important;
+}
+
+/* Category pills border top */
+.fwpl-item.el-lvcwxa {
+  border-top: 1px solid #efece7 !important;
+  padding-top: 12px !important;
+  margin-top: 12px !important;
+  font-size: 0 !important;
+}
+
+.fwpl-term {
+  font-size: 14px !important;
+}
+
+/* Default pills */
+.fwpl-term a {
+  background-color: #f1f1f1 !important;
+  border: 1px solid #d9d9d9 !important;
+  color: #515151 !important;
+  display: inline-block !important;
+  padding: 6px 12px !important;
+  border-radius: 8px !important;
+  margin: 0 4px 6px 0 !important;
+  text-decoration: none !important;
+  font-size: 0.8em !important;
+}
+
+.fwpl-term a:hover {
+  border-color: #999 !important;
+  background-color: #e8e8e8 !important;
+}
+
+/** 
+ * Category pill colors 
+ * used tetradic colors off https://www.colorhexa.com/e7bbb4
+ */
+/* all Resource pills & Timing category group*/
+.emfn-content-cards.wpnbha.show-category .cat-links a[href],
+.fwpl-term a[href] {
+  --cat-color: #f1f1f1;
+  background-color: var(--cat-color) !important;
+  border: 1px solid color-mix(in srgb, var(--cat-color), black 15%) !important;
+  color: color-mix(in srgb, var(--cat-color), black 66%) !important;
+}
+
+/* Disaster category group*/
+.emfn-content-cards.wpnbha.show-category .cat-links a[href*="resources/disasters/"],
+.fwpl-term a[href*="/resources/disasters/"] {
+  --cat-color: #e7bbb4;
+}
+
+/* Operational Challenge category group*/
+.emfn-content-cards.wpnbha.show-category .cat-links a[href*="resources/challenge/"],
+.fwpl-term a[href*="/resources/challenge/"] {
+  --cat-color: #b4e7bb;
+}
+/* Type category group*/
+.emfn-content-cards.wpnbha.show-category .cat-links a[href*="resources/type/"],
+.fwpl-term a[href*="/resources/type/"] {
+  --cat-color: #b4e0e7;
+}
+/* Newsroom Condition category group*/
+.emfn-content-cards.wpnbha.show-category .cat-links a[href*="resources/newsroom-condition/"],
+.fwpl-term a[href*="/resources/newsroom-condition/"] {
+  --cat-color: #e7b4e0;
 }

--- a/tools/templates/liteSitesFooter.html
+++ b/tools/templates/liteSitesFooter.html
@@ -1,7 +1,17 @@
 <p>
-Emergency Mode for News is for newsroom planners and activators — the people everyone looks to when a disaster happens. The program is a collaboration between <a href="https://www.opennews.org/" target="grantee">OpenNews ↗</a>, <a href="https://newspack.com/" target="grantee">Newspack ↗</a>, and <a href="https://nclocal.org/" target="grantee">NC Local ↗</a>, with funding from <a href="https://www.pressforward.news/" target="pressforward">Press Forward ↗</a>, a national initiative to reimagine local news.
+  Emergency Mode for News is for newsroom planners and activators — the people everyone looks to
+  when a disaster happens. The program is a collaboration between
+  <a href="https://www.opennews.org/" target="grantee">OpenNews ↗</a>,
+  <a href="https://newspack.com/" target="grantee">Newspack ↗</a>, and
+  <a href="https://nclocal.org/" target="grantee">NC Local ↗</a>, with funding from
+  <a href="https://www.pressforward.news/" target="pressforward">Press Forward ↗</a>, a national
+  initiative to reimagine local news.
 </p>
 <small style="color: #666">
-This Lite Site is powered by <a href="https://github.com/Automattic/newspack-lite-site" target="litesites">Newspack's Lite Site plugin ↗</a>.<br />
-<a href="/text/about/privacy-policy/">Privacy Policy</a> | <a href="/text/about/accessibility/">Accessibility Statement</a> | © 2026 Emergency Mode for News.
+  This Lite Site is powered by
+  <a href="https://github.com/Automattic/newspack-lite-site" target="litesites"
+    >Newspack's Lite Site plugin ↗</a
+  >.<br />
+  <a href="/text/about/privacy-policy/">Privacy Policy</a> |
+  <a href="/text/about/accessibility/">Accessibility Statement</a> | © 2026 Emergency Mode for News.
 </small>


### PR DESCRIPTION
1. devcontainer cleanup, after rounds of fighting with Copilot instrux around Node dependencies 
2. focus Dependabot PRs on `staging`, not the repo's root domain, which helps bring its primary back to `main`
3. `npm run format` cleanup on the new backups from the Newspack staging site 
4. latest `css.css` copy from WordPress, while site dev is continues and I don't (yet) have a child theme setup correctly here in this repo