### PR TITLE
Staging fix: re-activate matching logic

### DIFF
--- a/plugins/emfn-action-pack-plugin/assets/js/emfn-action-pack-plugin.js
+++ b/plugins/emfn-action-pack-plugin/assets/js/emfn-action-pack-plugin.js
@@ -944,11 +944,13 @@ const SubmissionHashing = {
  *   or script load events
  */
 
-/** only run any of this if there's a section.assessment DOM node
+/** Run if there's an assessment section or form (NOT on results page)
  * @type {HTMLElement | null}
  */
 const assessmentSection = document.querySelector("section.assessment");
-if (assessmentSection) {
+const hasForm = !!document.querySelector(gravityForm);
+
+if (assessmentSection || hasForm) {
   console.info("EMFN Action Pack Plugin active", version);
 
   SubmissionHashing.initializeSubmissionHandling();

--- a/plugins/emfn-action-pack-plugin/includes/class-emfn-action-pack-plugin.php
+++ b/plugins/emfn-action-pack-plugin/includes/class-emfn-action-pack-plugin.php
@@ -177,25 +177,28 @@ class EMFN_Action_Pack_Plugin {
             return $this->is_action_pack_page_request;
         }
 
+        // Check if actionPack query parameter is present (results page)
+        $has_action_pack_param = null !== $this->get_action_pack_payload_from_request();
+        if ( $has_action_pack_param ) {
+            $this->is_action_pack_page_request = true;
+            return $this->is_action_pack_page_request;
+        }
+
         $post = get_queried_object();
         if ( ! ( $post instanceof WP_Post ) ) {
             $this->is_action_pack_page_request = false;
             return $this->is_action_pack_page_request;
         }
 
-        $post_content = isset( $post->post_content ) ? (string) $post->post_content : '';
-        $post_slug    = isset( $post->post_name ) ? (string) $post->post_name : '';
-
-        // Check for CSS classes in content (for results page)
-        $has_action_pack_classes = false !== strpos( $post_content, 'emfn-action-pack' ) || false !== strpos( $post_content, 'emfn-forms' );
-
-        // Check for Gravity Forms (for assessment form page)
-        $has_gravity_forms = false !== strpos( $post_content, 'gravityform' ) || false !== strpos( $post_content, 'wp:gravityforms/form' );
+        $post_slug = isset( $post->post_name ) ? (string) $post->post_name : '';
 
         // Check if this is the action page by slug
-        $is_action_page = 'action' === $post_slug;
+        $is_action_page = 'action' === $post_slug || 'action-pack' === $post_slug;
 
-        $this->is_action_pack_page_request = $has_action_pack_classes || $has_gravity_forms || $is_action_page;
+        // Check for Gravity Forms block (for assessment form page)
+        $has_gravity_forms = has_block( 'gravityforms/form', $post );
+
+        $this->is_action_pack_page_request = $is_action_page || $has_gravity_forms;
 
         return $this->is_action_pack_page_request;
     }


### PR DESCRIPTION
This pull request updates the logic for detecting and activating the EMFN Action Pack Plugin on both the client and server sides. The main improvements are to better handle different types of assessment and results pages, ensuring the plugin is only activated when appropriate.

Detection improvements for plugin activation:

* The JavaScript now activates the plugin if either an assessment section or a Gravity Form is present on the page, rather than just checking for the assessment section. This ensures the plugin runs on all relevant assessment form pages.
* On the PHP side, the function that determines if the current request is for an Action Pack page now also checks for a specific query parameter (used on results pages), and improves detection by checking for both `action` and `action-pack` slugs, as well as the presence of a Gravity Forms block using `has_block`. It removes the less reliable method of searching for CSS classes or shortcodes in post content.