### PR TITLE
Live site CSS fixes and cleanup; dependabot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,9 @@
   "packages": {
     "": {
       "name": "emergencymode-news",
-      "version": "0.3.1",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
-        "@typescript-eslint/eslint-plugin": "^8.60.0",
+        "@typescript-eslint/eslint-plugin": "^8.60.1",
         "@typescript-eslint/parser": "^8.60.0",
         "eslint": "^10.4.1",
         "eslint-plugin-jsdoc": "^63.0.1",
@@ -1709,17 +1708,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.0.tgz",
-      "integrity": "sha512-QYb/sa74/s7OKMbACMjrYnGspj9Hs5YI5aaffSL65UfeBUzVzBJfVo3oWSpbzPurvm7yaCCo2Lk7lVj610HqKw==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
+      "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.60.0",
-        "@typescript-eslint/type-utils": "8.60.0",
-        "@typescript-eslint/utils": "8.60.0",
-        "@typescript-eslint/visitor-keys": "8.60.0",
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/type-utils": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1732,22 +1731,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.60.0",
+        "@typescript-eslint/parser": "^8.60.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.0.tgz",
-      "integrity": "sha512-fcqpj/MyK4sxDPcbe7STNPbpQL4RLZOPWuaTmwZYuc+hJKzRf58yRxfhqGpc6PIq9ZyfSBpfHgmUHmHs0KwHwg==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
+      "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.60.0",
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/typescript-estree": "8.60.0",
-        "@typescript-eslint/visitor-keys": "8.60.0",
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1763,14 +1762,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.0.tgz",
-      "integrity": "sha512-aZu74NNKJeUWqCjDddzdiKaS82dgYgV/vmf+Ui3ZdZejmgfXR/q+pRumgobnQ2cCJTgGTWp4ypiwsuofFubavg==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
+      "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.60.0",
-        "@typescript-eslint/types": "^8.60.0",
+        "@typescript-eslint/tsconfig-utils": "^8.60.1",
+        "@typescript-eslint/types": "^8.60.1",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1785,14 +1784,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.0.tgz",
-      "integrity": "sha512-pFzqhllJMs+jghLQWzV00ds39xLzuyqPSev5pd8f4Ir0rtKR3ZLUB4/4dhjOFighWb9larvtfJvqL+4yKDI3Xw==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
+      "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/visitor-keys": "8.60.0"
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1803,9 +1802,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.0.tgz",
-      "integrity": "sha512-BZPR3RGYlAXnly6ymAxfkVn5rCbZzQNou0rxv3GfWZ8cTQp+hhVd73khbGLAd8k1TlAPLISH337M+tAgAnaJDQ==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
+      "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1820,15 +1819,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.0.tgz",
-      "integrity": "sha512-SX46wEUtitCpq7AN38HkUU/+zvUpdKf7ephtWAFgckH8O7PQIyL5gvrhQgBLuEYgLfuKWOVvWVskMbuFHAz5xg==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
+      "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/typescript-estree": "8.60.0",
-        "@typescript-eslint/utils": "8.60.0",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1",
+        "@typescript-eslint/utils": "8.60.1",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1845,9 +1844,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.0.tgz",
-      "integrity": "sha512-AsE7x2XaAK+CVbeih0Fvbn+r1qHxtpLDJ3XUuFcIinT318T90yHMJC+Zgv+jUuDjQQd06HKwxnDu6sz1IcTilA==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
+      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1859,16 +1858,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.0.tgz",
-      "integrity": "sha512-3AcZNBGMClm6CXDyo8kYvVGT/sx29sS0oBsIb9oZI2gunA4Vm2M3YHzRLPvsUBBsl+yB5FPtltq7gGH0iTlp9g==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
+      "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.60.0",
-        "@typescript-eslint/tsconfig-utils": "8.60.0",
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/visitor-keys": "8.60.0",
+        "@typescript-eslint/project-service": "8.60.1",
+        "@typescript-eslint/tsconfig-utils": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/visitor-keys": "8.60.1",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1887,16 +1886,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.0.tgz",
-      "integrity": "sha512-HtXuPfrHTyBDkameWpl+vJb1Uevu2tznAyahM1Oc4AENidCLTPiZDWIo4GfcxNdC/RcfGcadzzkqbRG87dUrQA==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
+      "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.60.0",
-        "@typescript-eslint/types": "8.60.0",
-        "@typescript-eslint/typescript-estree": "8.60.0"
+        "@typescript-eslint/scope-manager": "8.60.1",
+        "@typescript-eslint/types": "8.60.1",
+        "@typescript-eslint/typescript-estree": "8.60.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1911,13 +1910,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.60.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.0.tgz",
-      "integrity": "sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==",
+      "version": "8.60.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
+      "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.60.0",
+        "@typescript-eslint/types": "8.60.1",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -5695,9 +5694,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@typescript-eslint/eslint-plugin": "^8.60.0",
+    "@typescript-eslint/eslint-plugin": "^8.60.1",
     "@typescript-eslint/parser": "^8.60.0",
     "eslint": "^10.4.1",
     "eslint-plugin-jsdoc": "^63.0.1",

--- a/plugins/emfn-site-styles-plugin/assets/css/emfn-site-styles-plugin.css
+++ b/plugins/emfn-site-styles-plugin/assets/css/emfn-site-styles-plugin.css
@@ -13,18 +13,6 @@
   --emfn-action-pack-visited: #00724c;
 }
 
-/*custom header*/
-.h-sb header#masthead {
-  backdrop-filter: blur(10px);
-  background-color: color-mix(
-    var(--newspack-header-color),
-    var(--emfn-background-color) 33%
-  ) !important;
-}
-.h-sb header#masthead .middle-header-contain {
-  background-color: transparent !important;
-}
-
 /* site title*/
 .site-title a {
   color: var(--newspack-primary-color) !important;
@@ -90,7 +78,7 @@ figure.emfn-table.wp-block-table tbody td {
   border-width: 0px;
 }
 figure.emfn-table.wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
-  background-color: ff1f1f1;
+  background-color: #f1f1f1;
 }
 
 /* apply our styles to Details blocks*/
@@ -646,9 +634,6 @@ body.parent-pageid-284 .entry-header {
 /* Facet's pagination drop-down */
 .facetwp-facet-load_more .facetwp-per-page-select {
   padding: 4px 16px;
-}
-select,
-::picker(select) {
   appearance: base-select;
 }
 

--- a/plugins/emfn-site-styles-plugin/assets/css/emfn-site-styles-plugin.css
+++ b/plugins/emfn-site-styles-plugin/assets/css/emfn-site-styles-plugin.css
@@ -1,22 +1,25 @@
 /*
- * EMFN style overrides 
- * ⏰ MANUALLY BACKED UP TO GITHUB! ⏰ 
+ * EMFN style overrides
  *
  * Enqueued after the main theme stylesheet, so these styles will take 
  * precedence over the default styles provided by the theme. 
  * But you may still need `!important` to fight long selectors or third-party plugin CSS
  */
 
-/*custom bkg*/
-body {
-  background-color: rgb(249, 248, 246);
+:root {
+  --emfn-header-footer: #efece7;
+  --emfn-action-pack-mint: #eefdf2;
+  --emfn-action-pack-green: #009966;
+  --emfn-action-pack-visited: #00724c;
 }
 
 /*custom header*/
 .h-sb header#masthead {
-  backdrop-filter: blur(12px);
-  background-color: rgba(249, 248, 246, 0.75) !important;
-  background-color: oklab(0.978916 0.00032109 0.00292373 / 0.8);
+  backdrop-filter: blur(10px);
+  background-color: color-mix(
+    var(--newspack-header-color),
+    var(--emfn-background-color) 33%
+  ) !important;
 }
 .h-sb header#masthead .middle-header-contain {
   background-color: transparent !important;
@@ -24,32 +27,24 @@ body {
 
 /* site title*/
 .site-title a {
-  color: #c1503d !important;
+  color: var(--newspack-primary-color) !important;
   font-size: 1rem;
-  font-family: "Roboto Slab", serif;
+  font-family: var(--newspack-theme-font-body);
+  text-transform: uppercase;
 }
 
 /* Show Breadcrumbs only on Archive pages*/
-.site-breadcrumb {
+.site-breadcrumb,
+body.author .site-breadcrumb {
   display: none !important;
 }
 body.archive .site-breadcrumb {
   display: inherit !important;
 }
 
-/* Hide breadcrumb on author archive pages specifically */
-body.author .site-breadcrumb {
-  display: none !important;
-}
-
 /*capitalize By in all normal bylines*/
 .entry-meta .byline:not(.sponsor-byline) > span {
   text-transform: capitalize;
-}
-
-/* restyle border on blockquotes */
-.h-stk .entry-content [id] {
-  border-color: #b7b4af;
 }
 
 /* for all Posts body copy, control internal hyperlink color*/
@@ -82,26 +77,26 @@ figure.emfn-table.wp-block-table > table {
   max-width: 80% !important;
 }
 figure.emfn-table.wp-block-table thead {
-  border-color: #b7b4af;
+  border-color: var(--newspack-listings--grey-medium);
 }
 figure.emfn-table.wp-block-table thead th {
   border: none;
 }
 figure.emfn-table.wp-block-table tbody tr:not(:last-of-type) {
-  border: 1px solid #b7b4af;
+  border: 1px solid var(--newspack-listings--grey-medium);
   border-width: 1px 0px;
 }
 figure.emfn-table.wp-block-table tbody td {
   border-width: 0px;
 }
 figure.emfn-table.wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
-  background-color: #efece7;
+  background-color: ff1f1f1;
 }
 
 /* apply our styles to Details blocks*/
 .wp-block-details {
   border-width: 0px;
-  border-bottom: 1px solid #b7b4af;
+  border-bottom: 1px solid var(--newspack-listings--grey-medium);
   display: block;
   width: 100%;
   margin-bottom: 32px !important;
@@ -124,14 +119,12 @@ figure.emfn-table.wp-block-table.is-style-stripes tbody tr:nth-child(odd) {
 body.home .site-breadcrumb {
   display: none !important;
 }
-
 /* Content - Breadcrumbs */
 @media (min-width: 782px) {
   .site-breadcrumb {
     margin: 1.5rem 0 0.25rem;
   }
 }
-
 .site-breadcrumb .wrapper > span {
   color: var(--newspack-theme-color-text-main);
   display: flex;
@@ -140,21 +133,9 @@ body.home .site-breadcrumb {
   font-size: 14px;
   gap: 0.5em;
 }
-
 .site-breadcrumb .breadcrumb_last {
   font-weight: bold;
   border-bottom: 2px solid var(--newspack-theme-color-secondary);
-}
-
-/*hide search bar in header*/
-body.home .header-search-contain {
-  display: none !important;
-}
-
-/*hide >4 categories on Post pages (9 = 4, because hidden commas) */
-/* Newspack's 'only show Yoast primary category' flag SHOULD drive this, but if it is turned off this is a catch-all */
-.cat-links > :nth-child(n + 9) {
-  display: none;
 }
 
 /*left-align logo*/
@@ -174,8 +155,8 @@ body.home .header-search-contain {
 
 /*convert nav3/tertiary to our style of button*/
 .site-header .nav3 li a {
-  background-color: #c1503d !important;
-  color: #fff !important;
+  background-color: var(--newspack-primary-color) !important;
+  color: var(--newspack-primary-contrast-color) !important;
   border-radius: 32px;
   padding: 6px 24px;
   text-align: center;
@@ -202,10 +183,10 @@ body.home .header-search-contain {
  */
 /* action items*/
 .action-item {
-  background-color: oklab(0.98 -0.02 0.01);
+  background-color: var(--emfn-action-pack-mint);
   border-radius: 16px;
   padding: 20px;
-  color: #009966;
+  color: var(--emfn-action-pack-green);
   list-style: none;
   margin: 0px;
 }
@@ -215,7 +196,7 @@ body.home .header-search-contain {
 .action-item a,
 .action-item a:link,
 .action-item a:visited {
-  color: #00724c;
+  color: var(--emfn-action-pack-visited);
 }
 .action-item li.template {
   display: flex;
@@ -241,41 +222,52 @@ body.parent-pageid-284 .entry-header {
 
 /*Content Loop adjustments*/
 .emfn-content-cards.wpnbha .article-section-title {
-  border-bottom: 1px solid #e3e1dd;
+  border-bottom: 1px solid var(--newspack-theme-color-border-light);
 }
+/* this may not apply to anything? */
 .archive article.entry .entry-content > * {
-  border-top: 1px solid #e3e1dd;
+  border-top: 1px solid var(--newspack-theme-color-border-light);
   padding-top: 0px;
   margin-top: 0px;
 }
 .emfn-content-cards.wpnbha article,
 .archive article.entry {
   padding: 24px 36px 20px 36px;
-  background-color: #fff;
+  background-color: var(--newspack-primary-contrast-color);
   border-radius: 24px;
-  border: 1px solid #e2e2e2;
+  border: 1px solid var(--newspack-theme-color-border-light);
   box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px;
 }
 
 /* Republishable Card Peach */
+:root {
+  --republishable-peach: #fff7ed;
+  --republishable-peach-border: #ffd7a8;
+}
 .emfn-content-cards.wpnbha article.category-republishable {
-  background-color: #fff7ed;
-  border: 1px solid #ffd7a8;
+  background-color: var(--republishable-peach);
+  border: 1px solid var(--republishable-peach-border);
 }
 .emfn-content-cards.wpnbha article.category-republishable .entry-wrapper .entry-meta {
-  border-top-color: #ffd7a8;
+  border-top-color: var(--republishable-peach-border);
 }
 /* Republishable Category link */
 .emfn-content-cards.wpnbha article.category-republishable .cat-links a {
-  color: #9f2d00;
-  border: 1px solid #ffd7a8;
-  background-color: #efece750;
+  display: none;
+}
+/* Republishable Card byline */
+.emfn-content-cards.wpnbha article.category-republishable .entry-wrapper .entry-meta .byline {
+  color: var(--newspack-theme-color-secondary-variation-against-white);
+}
+/* Republishable card byline links need to be a bit darker for accessibility */
+.emfn-content-cards.wpnbha article.category-republishable .entry-wrapper .entry-meta .byline a {
+  color: var(--newspack-theme-color-primary-variation-against-white);
 }
 
 /*all Card Categories*/
 .emfn-content-cards.wpnbha .cat-links a {
-  background-color: #fff;
-  border: 1px solid #ccc;
+  background-color: var(--newspack-primary-contrast-color);
+  border: 1px solid var(--newspack-ui-color-neutral-40);
   color: var(--newspack-theme-color-text-light);
   gap: 0em 1em;
   display: inline-block;
@@ -285,9 +277,9 @@ body.parent-pageid-284 .entry-header {
 }
 .emfn-content-cards.wpnbha .cat-links a:hover,
 .emfn-content-cards.wpnbha .cat-links a:link:hover {
-  border-color: #999;
+  border-color: var(--newspack-ui-color-neutral-50);
   color: var(--newspack-theme-color-text-medium);
-  background-color: #efece790;
+  background-color: var(--newspack-primary-contrast-color);
   text-decoration-color: var(--newspack-theme-color-text-medium);
 }
 .emfn-content-cards.wpnbha .entry-sponsors {
@@ -300,7 +292,7 @@ body.parent-pageid-284 .entry-header {
 /*Card bylines*/
 .emfn-content-cards.wpnbha .entry-wrapper .entry-meta {
   color: var(--newspack-theme-color-text-light);
-  border-top: 1px solid #efece7;
+  border-top: 1px solid var(--newspack-theme-color-border-light);
   gap: 0.5em 0.25em;
   margin-top: 12px;
   padding-top: 12px;
@@ -320,22 +312,22 @@ body.parent-pageid-284 .entry-header {
   padding: 6px 0px;
 }
 .single:not(.has-large-featured-image) .entry-header {
-  border-bottom-color: #ccc;
+  border-bottom-color: var(--newspack-ui-color-neutral-40);
 }
 
 /* Content Loop load-more button */
 .emfn-content-cards.wpnbha.has-more-button button {
-  background-color: #fff;
+  background-color: var(--newspack-primary-contrast-color);
   border-radius: 8px;
-  border: 1px solid #888;
+  border: 1px solid var(--newspack-ui-color-neutral-50);
   box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px;
   color: var(--newspack-theme-color-primary);
   margin-top: 2em;
   padding: 8px 18px;
 }
 .emfn-content-cards.wpnbha.has-more-button button:hover {
-  background-color: #e8e8e8;
-  border-color: #666;
+  background-color: var(--newspack-ui-color-neutral-10);
+  border-color: var(--newspack-theme-color-secondary);
 }
 
 /** ********* MORE BUTTONS ********** 
@@ -345,9 +337,9 @@ body.parent-pageid-284 .entry-header {
  */
 .facetwp-facet-load_more .facetwp-per-page-select,
 .emfn-content-cards.wpnbha.has-more-button button {
-  background-color: #fff;
+  background-color: var(--newspack-primary-contrast-color);
   border-radius: 8px;
-  border: 1px solid #888;
+  border: 1px solid var(--newspack-ui-color-neutral-50);
   box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px;
   color: var(--newspack-theme-color-primary);
   font-size: var(--newspack-theme-font-size-sm);
@@ -356,8 +348,8 @@ body.parent-pageid-284 .entry-header {
 
 .facetwp-facet-load_more .facetwp-per-page-select:hover,
 .emfn-content-cards.wpnbha.has-more-button button:hover {
-  background-color: #e8e8e8;
-  border-color: #666;
+  background-color: var(--newspack-ui-color-neutral-30);
+  border-color: var(--newspack-theme-color-secondary);
 }
 
 /** ********** SPONSOR & CATEGORY LABELS ********** 
@@ -371,26 +363,31 @@ body.parent-pageid-284 .entry-header {
   display: none;
 }
 
-/* alter non-Card Category labels */
+/* all Category labels */
 .cat-links a {
-  color: #fff;
+  color: var(--newspack-primary-contrast-color);
   text-transform: none;
   border: 1px solid var(--newspack-theme-color-primary-darken-10);
   background-color: var(--newspack-theme-color-primary);
   display: inline-block;
-  padding: 6px 12px;
+  padding: 6px 12px !important;
   border-radius: 8px;
   margin-bottom: 10px;
   text-decoration: none;
+  transition: all 0.15s ease-in-out;
 }
-.cat-links a:hover {
-  background-color: var(--newspack-theme-color-primary-darken-10);
+/* featured media - white text on black */
+@media only screen and (min-width: 782px) {
+  .featured-image-beside .cat-links a {
+    padding: inherit;
+  }
 }
 
 /* alter non-Card Tags */
 .tags-links a {
-  border: 1px solid #ccc;
-  background-color: #fff;
+  border: 1px solid var(--newspack-ui-color-neutral-40);
+  background-color: var(--newspack-ui-color-neutral-5) !important;
+  color: var(--newspack-theme-color-primary-variation-against-white) !important;
   padding: 10px 15px;
   border-radius: 8px;
   line-height: 1em;
@@ -398,7 +395,16 @@ body.parent-pageid-284 .entry-header {
   box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px;
 }
 .tags-links a:hover {
-  border-color: #999;
+  border-color: var(--newspack-ui-color-neutral-50) !important;
+  background-color: var(--newspack-ui-color-neutral-10) !important;
+}
+
+/* make Sponsor logos a circle */
+.wpnbha .sponsor-logos img {
+  border-radius: 50%;
+  object-fit: cover;
+  width: 40px;
+  height: 40px;
 }
 
 /** 
@@ -407,7 +413,7 @@ body.parent-pageid-284 .entry-header {
  */
 /* all Resource pills & Timing category group*/
 .emfn-content-cards.wpnbha.show-category .cat-links a[href] {
-  --cat-color: #f1f1f1;
+  --cat-color: var(--newspack-ui-color-neutral-5);
   background-color: var(--cat-color);
   border: 1px solid color-mix(in srgb, var(--cat-color), black 15%);
   color: color-mix(in srgb, var(--cat-color), black 66%);
@@ -429,47 +435,6 @@ body.parent-pageid-284 .entry-header {
 /* Newsroom Condition category group*/
 .emfn-content-cards.wpnbha.show-category .cat-links a[href*="resources/newsroom-condition/"] {
   --cat-color: #e7b4e0;
-}
-
-/** ********** JETPACK AI SEARCH ********** 
- * styles overrides for Jetpack AI search box and results
- * -
- */
-/*Jetpack AI search*/
-.emfn-ai-search {
-  min-height: 50px;
-  width: 100%;
-}
-.emfn-ai-search .jetpack-ai-chat-question-wrapper,
-.emfn-ai-search .jetpack-ai-chat-question-input {
-  margin: 0px !important;
-}
-.emfn-ai-search input[type="text"],
-.emfn-ai-search button[type="button"] {
-  background-color: #fff;
-  border-radius: 8px;
-  box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px;
-  color: var(--newspack-theme-color-primary);
-  padding: 14px 18px;
-  border: 1px solid #888;
-  color: #c1503d;
-  height: 50px !important;
-}
-.emfn-ai-search input[type="text"]:focus {
-  background-color: #fff;
-  border-color: #c1503d;
-  box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px;
-}
-.emfn-ai-search button[type="button"]:hover,
-.emfn-ai-search button[type="button"]:active,
-.emfn-ai-search button[type="button"]:focus {
-  background-color: #e8e8e8;
-  box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px;
-  border-color: #777;
-  color: #c1503d;
-}
-.emfn-ai-search .jetpack-ai-chat-copy-button {
-  padding: 0px 10px;
 }
 
 /** ********** SYMBOLS FONT ********** 
@@ -522,7 +487,7 @@ body.parent-pageid-284 .entry-header {
   position: relative;
   height: 1.3em; /* reserves space for one line */
   text-align: center;
-  color: #c1503d;
+  color: var(--newspack-primary-color);
 }
 
 .emfn-word {
@@ -530,7 +495,7 @@ body.parent-pageid-284 .entry-header {
   left: 0;
   right: 0;
   text-align: center;
-  color: #c1503d;
+  color: var(--newspack-primary-color);
   opacity: 0;
   pointer-events: none;
   /* no transition on inactive words — instant hide */
@@ -549,8 +514,6 @@ body.parent-pageid-284 .entry-header {
 }
 
 .schema-faq .schema-faq-section .schema-faq-question:before {
-  /* 	content: "Q. ";
-	content: "ⓘ "; */
   content: "🛈 ";
   color: var(--newspack-theme-color-primary) !important;
   font-size: var(--newspack-theme-font-size-md);
@@ -570,8 +533,8 @@ body.parent-pageid-284 .entry-header {
   background-color: transparent;
 }
 .emfn-tabs.wp-block-newspack-tabs .tab-item.is-active {
-  background-color: #fff;
-  border: 1px solid #e8e8e8;
+  background-color: var(--newspack-primary-contrast-color);
+  border: 1px solid var(--newspack-ui-color-neutral-30);
 }
 
 /** ********** FACETWP CARDS ********** 
@@ -585,9 +548,9 @@ body.parent-pageid-284 .entry-header {
   }
 }
 .fwpl-result {
-  background-color: #fff !important;
+  background-color: var(--newspack-primary-contrast-color) !important;
   border-radius: 24px !important;
-  border: 1px solid #e2e2e2 !important;
+  border: 1px solid var(--newspack-theme-color-border-light) !important;
   box-shadow: rgba(0, 0, 0, 0.03) 0px 0px 6px 2px !important;
   padding: 24px 36px 20px 36px !important;
   margin-bottom: 1rem !important;
@@ -597,7 +560,7 @@ body.parent-pageid-284 .entry-header {
 .fwpl-item.el-ywvhp a {
   font-size: 1.2em !important;
   font-weight: 700 !important;
-  color: #1b2232 !important;
+  color: var(--newspack-secondary-color) !important;
   text-decoration: none !important;
   font-family: var(--newspack-theme-font-heading) !important;
 }
@@ -630,7 +593,7 @@ body.parent-pageid-284 .entry-header {
 }
 
 .fwpl-btn {
-  color: #1b2232 !important;
+  color: var(--newspack-secondary-color) !important;
   text-decoration: underline !important;
   font-size: 0.9em !important;
 }
@@ -645,17 +608,17 @@ body.parent-pageid-284 .entry-header {
 
 /* Search bar */
 .facetwp-search {
-  border: 1px solid #ccc !important;
+  border: 1px solid var(--newspack-ui-color-neutral-40) !important;
   border-radius: 8px !important;
   padding: 10px 16px !important;
   font-size: var(--newspack-theme-font-size-sm) !important;
   width: 100% !important;
-  background-color: #fff !important;
+  background-color: var(--newspack-primary-contrast-color) !important;
   color: var(--newspack-theme-color-text-main) !important;
 }
 
 .facetwp-search:focus {
-  border-color: #1b2232 !important;
+  border-color: var(--newspack-secondary-color) !important;
   outline: none !important;
 }
 
@@ -670,7 +633,7 @@ body.parent-pageid-284 .entry-header {
 
 /* Category pills border top */
 .fwpl-item.el-lvcwxa {
-  border-top: 1px solid #efece7 !important;
+  border-top: 1px solid var(--emfn-header-footer) !important;
   padding-top: 12px !important;
   margin-top: 12px !important;
   font-size: 0 !important;
@@ -680,11 +643,20 @@ body.parent-pageid-284 .entry-header {
   font-size: 14px !important;
 }
 
+/* Facet's pagination drop-down */
+.facetwp-facet-load_more .facetwp-per-page-select {
+  padding: 4px 16px;
+}
+select,
+::picker(select) {
+  appearance: base-select;
+}
+
 /* Default pills */
 .fwpl-term a {
-  background-color: #f1f1f1 !important;
-  border: 1px solid #d9d9d9 !important;
-  color: #515151 !important;
+  background-color: var(--newspack-ui-color-neutral-5) !important;
+  border: 1px solid var(--newspack-ui-color-neutral-50) !important;
+  color: var(--newspack-ui-color-neutral-60) !important;
   display: inline-block !important;
   padding: 6px 12px !important;
   border-radius: 8px !important;
@@ -694,8 +666,8 @@ body.parent-pageid-284 .entry-header {
 }
 
 .fwpl-term a:hover {
-  border-color: #999 !important;
-  background-color: #e8e8e8 !important;
+  border-color: var(--newspack-ui-color-neutral-50) !important;
+  background-color: var(--newspack-ui-color-neutral-30) !important;
 }
 
 /** 
@@ -703,32 +675,40 @@ body.parent-pageid-284 .entry-header {
  * used tetradic colors off https://www.colorhexa.com/e7bbb4
  */
 /* all Resource pills & Timing category group*/
-.emfn-content-cards.wpnbha.show-category .cat-links a[href],
+.cat-links a[href],
 .fwpl-term a[href] {
-  --cat-color: #f1f1f1;
+  --cat-color: var(--newspack-ui-color-neutral-5);
   background-color: var(--cat-color) !important;
   border: 1px solid color-mix(in srgb, var(--cat-color), black 15%) !important;
   color: color-mix(in srgb, var(--cat-color), black 66%) !important;
+  transition: all 0.15s ease-in-out;
+}
+.cat-links a[href]:hover,
+.fwpl-term a[href]:hover,
+.cat-links a[href]:active,
+.fwpl-term a[href]:active {
+  background-color: color-mix(in srgb, var(--cat-color), black 10%) !important;
+  border-color: color-mix(in srgb, var(--cat-color), black 20%) !important;
 }
 
 /* Disaster category group*/
-.emfn-content-cards.wpnbha.show-category .cat-links a[href*="resources/disasters/"],
+.cat-links a[href*="resources/disasters/"],
 .fwpl-term a[href*="/resources/disasters/"] {
   --cat-color: #e7bbb4;
 }
 
 /* Operational Challenge category group*/
-.emfn-content-cards.wpnbha.show-category .cat-links a[href*="resources/challenge/"],
+.cat-links a[href*="resources/challenge/"],
 .fwpl-term a[href*="/resources/challenge/"] {
   --cat-color: #b4e7bb;
 }
 /* Type category group*/
-.emfn-content-cards.wpnbha.show-category .cat-links a[href*="resources/type/"],
+.cat-links a[href*="resources/type/"],
 .fwpl-term a[href*="/resources/type/"] {
   --cat-color: #b4e0e7;
 }
 /* Newsroom Condition category group*/
-.emfn-content-cards.wpnbha.show-category .cat-links a[href*="resources/newsroom-condition/"],
+.cat-links a[href*="resources/newsroom-condition/"],
 .fwpl-term a[href*="/resources/newsroom-condition/"] {
   --cat-color: #e7b4e0;
 }


### PR DESCRIPTION
This pull request primarily updates the `emfn-site-styles-plugin.css` stylesheet to improve maintainability and consistency by replacing hardcoded color values with CSS variables, aligning styles more closely with the Newspack theme, and removing some unused or redundant code. There is also a minor update to a development dependency in `package.json`.

## Work

* Replaced most hardcoded color values throughout `emfn-site-styles-plugin.css` with CSS variables (e.g., `var(--newspack-primary-color)`, `var(--emfn-action-pack-mint)`), making the stylesheet easier to maintain and more consistent with the Newspack theme
* Added new CSS variables for custom colors (e.g., `--emfn-header-footer`, `--republishable-peach`, etc.) and used them for relevant elements, further centralizing color management
* Improved accessibility and visual distinction for bylines and category/tag links, including specific adjustments for republishable card elements and sponsor logos
* Removed unused or redundant CSS rules, such as the Jetpack AI Search overrides and some specific breadcrumb/category display tweaks, to streamline the stylesheet
* https://github.com/OpenNews/emergencymode.news/pull/61